### PR TITLE
Implement Handshake Send REPLCONF

### DIFF
--- a/app/server.rb
+++ b/app/server.rb
@@ -156,6 +156,8 @@ class YourRedisServer
       connection.puts("*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n")
       response = connection.recv(1024)
       puts "received second REPLCONF response: #{response.strip}"
+      connection.puts("*3\r\n$5\r\nPSYNC\r\n$1\r\n?\r\n$2\r\n-1\r\n")
+      response = connection.recv(1024)
     else
       puts "no response received from master"
     end

--- a/app/server.rb
+++ b/app/server.rb
@@ -120,6 +120,7 @@
 # YourRedisServer.new(6379).start
 require 'socket'
 require 'optparse'
+require 'timeout'
 require_relative 'store_object'
 require_relative 'server_info_stats'
 
@@ -128,11 +129,47 @@ class YourRedisServer
     @server = TCPServer.new(options[:port])
     @data_store = {}
     @info_stats = ServerInfoStats.new(options)
+    @master_host = options[:master_host]
+    @master_port = options[:master_port]
+    if @master_host && @master_port
+      create_handshake
+    end
+  end
+  
+  def create_handshake
+    connection = TCPSocket.new(@master_host, @master_port)
+    connection.puts("*1\r\n$4\r\nPING\r\n")
+
+    response = nil
+    begin
+      Timeout.timeout(5) do
+        response = connection.recv(1024)
+      end
+    rescue Timeout::Error
+      puts "Timeout waiting for response from master" 
+    end
+
+    if response
+      puts "received initial REPLCONF response: #{response.strip}"
+      connection.puts("*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n")
+      response = connection.recv(1024)
+      connection.puts("*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n")
+      response = connection.recv(1024)
+      puts "received second REPLCONF response: #{response.strip}"
+    else
+      puts "no response received from master"
+    end
+
+    connection.close
+    # connection.puts("*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n")
+  rescue Errno::ECONNREFUSED => e
+    puts "Master not available: #{e.message}"
   end
 
   def start
     loop do
       Thread.start(@server.accept) do |client|
+        # create_handshake if @master_host && @master_port
         handle_client(client)
       end
     end
@@ -141,6 +178,7 @@ class YourRedisServer
   def handle_client(client)
     loop do
       request = client.gets
+      puts "Response from Master server #{request}"
       break if request.nil?
 
       request_parts = parse_request(request, client)
@@ -177,7 +215,7 @@ class YourRedisServer
     command = request_parts[0]
 
     case command.upcase
-    when "INFO"
+     when "INFO"
       section = request_parts[1]
       if section == "replication"
         role_pair = "#role:#{@info_stats.get_role}"
@@ -226,9 +264,20 @@ OptionParser.new do |opts|
   end
   # tune this up (argument formatting)
    opts.on("-r [S]", "--[no-]replicaof [S]", "Specified Master Host and Port Number") do |v|
-     v ? options[:role] = "slave" : options[:role] = "master"
+    p "v #{v}"
+    #  v ? options[:role] = "slave" : options[:role] = "master"
+     if v
+      options[:role] = "slave"
+      master_host, master_port = v.split(" ")
+      options[:master_host] = master_host 
+      options[:master_port] = master_port
+     else
+      options[:role] = "master"
+     end
   end
+p "Options #{options}"
 end.parse!(into: options)
 p "Print options #{options}"
-YourRedisServer.new(options).start
+p "Print :role option #{options[:role]}"
 
+YourRedisServer.new(options).start


### PR DESCRIPTION
The replica sends REPLCONF twice to the master (This stage) 

After receiving a response to PING, the replica then sends 2 [REPLCONF](https://redis.io/commands/replconf/) commands to the master.

The REPLCONF command is used to configure replication. Replicas will send this command to the master twice:

The first time, it'll be sent like this: REPLCONF listening-port <PORT>
This is the replica notifying the master of the port it's listening on
The second time, it'll be sent like this: REPLCONF capa psync2
This is the replica notifying the master of its capabilities ("capa" is short for "capabilities")
You can safely hardcode these capabilities for now, we won't need to use them in this challenge.
These commands should be sent as RESP Arrays, so the exact bytes will look something like this:

# REPLCONF listening-port <PORT>
*3\r\n$8\r\nREPLCONF\r\n$14\r\nlistening-port\r\n$4\r\n6380\r\n

# REPLCONF capa psync2
*3\r\n$8\r\nREPLCONF\r\n$4\r\ncapa\r\n$6\r\npsync2\r\n
For both commands, the master will respond with +OK\r\n ("OK" encoded as a RESP Simple String).